### PR TITLE
deploy-users.yml: fix ansible-ssh-deployment  path

### DIFF
--- a/deploy-users.yml
+++ b/deploy-users.yml
@@ -149,7 +149,7 @@
 
     - name: Write users' public ssh key to users' authorized_key files
       include_role:
-        name: ansible_roles/collections/ansible_collections/tosit/tdp-extra/ansible-ssh-deployment
+        name: ansible_roles/collections/ansible_collections/tosit/tdp-extra/roles/ansible-ssh-deployment
         tasks_from: add-user-ssh-to-authorized_keys-file
       with_items: "{{ groups['all'] }}"
       loop_control:


### PR DESCRIPTION
Corrected path to `ansible-ssh-deployment` role to fix `deploy-users.yml`