### PR TITLE
Fix issue 68

### DIFF
--- a/scripts/git-commit-download.sh
+++ b/scripts/git-commit-download.sh
@@ -4,8 +4,7 @@
 # Bash script to download git archive
 ###
 
-root_dir="$(dirname "$0")/.." # project root dir
-target_dir="$root_dir/$1"
+target_dir="$1"
 target_repository_url="$2"
 target_commit="$3"
 archive_filename="$target_commit.zip"

--- a/scripts/git-commit-download.sh
+++ b/scripts/git-commit-download.sh
@@ -24,7 +24,6 @@ print_usage() {
 }
 
 get_git_repository_commit() {
-
   wget -O "/tmp/$archive_filename" "$archive_download_uri"
   unzip -o "/tmp/$archive_filename" -d /tmp
   mkdir -p "$target_dir"

--- a/scripts/git-commit-download.sh
+++ b/scripts/git-commit-download.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+###
+# Bash script to download git archive
+###
+
+print_usage() {
+  echo """
+  Usage: git-commit-download.sh <target_directory> <github_repo_url> <target_commit>
+
+  Note: This script downloads and extracts a github hosted project at a specific commit. Takes 3 mandatory args:
+
+    - target_directory e.g. ansible_roles/collections/ansible_collections/tosit/tdp
+    - github_repo_url e.g. https://github.com/TOSIT-IO/tdp-collection
+    - target_commit e.g.abb3a24c43ba6ade109e93c187a77999ab919349
+  """
+}
+
+get_git_repository_commit() {
+
+  root_dir="$(dirname "$0")/.." # project root dir
+  target_dir="$root_dir/$1"
+  target_repository_url="$2"
+  target_commit="$3"
+  archive_filename="$target_commit.zip"
+  repository_name="$(basename $target_repository_url)"
+  archive_download_uri="$target_repository_url/archive/$archive_filename"
+
+  wget -O "/tmp/$archive_filename" "$archive_download_uri"
+  unzip -o "/tmp/$archive_filename" -d /tmp
+  mkdir -p "$target_dir"
+  cp -r "/tmp/$repository_name-$target_commit/." "$target_dir"
+}
+
+print_usage
+get_git_repository_commit

--- a/scripts/git-commit-download.sh
+++ b/scripts/git-commit-download.sh
@@ -18,6 +18,11 @@ print_usage() {
 
 get_git_repository_commit() {
 
+  if [ "$#" -ne 3 ]; then
+  echo "Missing arguments. Exiting." >&2
+  exit 1
+  fi
+
   root_dir="$(dirname "$0")/.." # project root dir
   target_dir="$root_dir/$1"
   target_repository_url="$2"
@@ -32,5 +37,8 @@ get_git_repository_commit() {
   cp -r "/tmp/$repository_name-$target_commit/." "$target_dir"
 }
 
-print_usage
+while getopts 'h' flag; do
+  print_usage && exit 1
+done
+
 get_git_repository_commit

--- a/scripts/git-commit-download.sh
+++ b/scripts/git-commit-download.sh
@@ -4,6 +4,14 @@
 # Bash script to download git archive
 ###
 
+root_dir="$(dirname "$0")/.." # project root dir
+target_dir="$root_dir/$1"
+target_repository_url="$2"
+target_commit="$3"
+archive_filename="$target_commit.zip"
+repository_name="$(basename $target_repository_url)"
+archive_download_uri="$target_repository_url/archive/$archive_filename"
+
 print_usage() {
   echo """
   Usage: git-commit-download.sh <target_directory> <github_repo_url> <target_commit>
@@ -17,19 +25,6 @@ print_usage() {
 }
 
 get_git_repository_commit() {
-
-  if [ "$#" -ne 3 ]; then
-  echo "Missing arguments. Exiting." >&2
-  exit 1
-  fi
-
-  root_dir="$(dirname "$0")/.." # project root dir
-  target_dir="$root_dir/$1"
-  target_repository_url="$2"
-  target_commit="$3"
-  archive_filename="$target_commit.zip"
-  repository_name="$(basename $target_repository_url)"
-  archive_download_uri="$target_repository_url/archive/$archive_filename"
 
   wget -O "/tmp/$archive_filename" "$archive_download_uri"
   unzip -o "/tmp/$archive_filename" -d /tmp

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,6 +5,8 @@
 # virtual TDP cluster using the TDP-getting-started repo
 ###
 
+
+
 # tdp-collection
 TDP_COLLECTION_URL=https://github.com/TOSIT-IO/tdp-collection
 TDP_ROLES_PATH=ansible_roles/collections/ansible_collections/tosit/tdp
@@ -15,28 +17,32 @@ TDP_COLLECTION_EXTRAS_URL=https://github.com/TOSIT-IO/tdp-collection-extras
 TDP_ROLES_EXTRA_PATH=ansible_roles/collections/ansible_collections/tosit/tdp-extra
 TDP_COLLECTION_EXTRAS_COMMIT=1035ca7f3f67275140cd15478d043b543679ec30
 
+root_dir="$(dirname "$0")/.." # project root dir
+EXPANDED_TDP_ROLES_PATH="$(realpath "$root_dir")/$TDP_ROLES_PATH"
+EXPANDED_TDP_ROLES_EXTRA_PATH="$(realpath "$root_dir")/$TDP_ROLES_EXTRA_PATH"
+
 # Create directories
 mkdir -p logs
 mkdir -p files
 
 # Clone ansible-tdp-roles repository (doesn't fail iof not known host)
-[[ -d "$TDP_ROLES_PATH" ]] || scripts/git-commit-download.sh $TDP_ROLES_PATH $TDP_COLLECTION_URL $TDP_COLLECTION_COMMIT
+[[ -d "$EXPANDED_TDP_ROLES_PATH" ]] || "$(realpath "$root_dir")/scripts/git-commit-download.sh" $EXPANDED_TDP_ROLES_PATH $TDP_COLLECTION_URL $TDP_COLLECTION_COMMIT
 
-[[ -d "$TDP_ROLES_EXTRA_PATH" ]] || scripts/git-commit-download.sh $TDP_ROLES_EXTRA_PATH $TDP_COLLECTION_EXTRAS_URL $TDP_COLLECTION_EXTRAS_COMMIT
+[[ -d "$TDP_ROLES_EXTRA_PATH" ]] || "$(realpath "$root_dir")/scripts/git-commit-download.sh" $EXPANDED_TDP_ROLES_EXTRA_PATH $TDP_COLLECTION_EXTRAS_URL $TDP_COLLECTION_EXTRAS_COMMIT
 
 # Quick fix for file lookup related to the Hadoop role refactor (https://github.com/TOSIT-FR/ansible-tdp-roles/pull/57)
 
-[[ -d $TDP_ROLES_PATH/playbooks/files ]] || ln -s $PWD/files $TDP_ROLES_PATH/playbooks
+[[ -d $EXPANDED_TDP_ROLES_PATH/playbooks/files ]] || ln -s "$(realpath "$root_dir")/files" $EXPANDED_TDP_ROLES_PATH/playbooks
 
 # Copy the default tdp_vars
-[[ -d inventory/tdp_vars ]] || cp -r ansible_roles/collections/ansible_collections/tosit/tdp/tdp_vars_defaults inventory/tdp_vars
+[[ -d "$(realpath "$root_dir")/inventory/tdp_vars" ]] || cp -r $EXPANDED_TDP_ROLES_PATH/tdp_vars_defaults "$(realpath "$root_dir")/inventory/tdp_vars"
 
 # Read the TDP releases from file
-tdp_release_uris=$(sed -E '/^[[:blank:]]*(#|$)/d; s/#.*//' $PWD/tdp-release-uris)
+tdp_release_uris=$(sed -E '/^[[:blank:]]*(#|$)/d; s/#.*//' "$(realpath "$root_dir")/scripts/tdp-release-uris.txt")
 
 # Fetch the TDP .tar.gz releases
 for tdp_release_uri in $tdp_release_uris; do
     release_name=$(basename $tdp_release_uri)
     # Fetch the TDP .tar.gz releases
-    [[ -f "$PWD/files/$release_name" ]] || wget $tdp_release_uri -nc -nd -O $PWD/files/$release_name
+    [[ -f "$(realpath "$root_dir")/files/$release_name" ]] || wget $tdp_release_uri -nc -nd -O "$(realpath "$root_dir")/files/$release_name"
 done

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,32 +5,38 @@
 # virtual TDP cluster using the TDP-getting-started repo
 ###
 
-# Get tdp-getting-started root dir
-root_dir="$(dirname "$0")/.."
+# tdp-collection
+TDP_COLLECTION_URL=https://github.com/TOSIT-IO/tdp-collection
+TDP_ROLES_PATH=ansible_roles/collections/ansible_collections/tosit/tdp
+TDP_COLLECTION_COMMIT=86f2d3f42df18a5ac07cc25e847ddaf3082be6d4
 
-TDP_ROLES_PATH="$root_dir/ansible_roles/collections/ansible_collections/tosit/tdp"
-TDP_ROLES_EXTRA_PATH="$root_dir/ansible_roles/collections/ansible_collections/tosit/tdp-extra"
+# tdp-collection-extras
+TDP_COLLECTION_EXTRAS_URL=https://github.com/TOSIT-IO/tdp-collection-extras
+TDP_ROLES_EXTRA_PATH=ansible_roles/collections/ansible_collections/tosit/tdp-extra
+TDP_COLLECTION_EXTRAS_COMMIT=1035ca7f3f67275140cd15478d043b543679ec30
 
 # Create directories
 mkdir -p logs
 mkdir -p files
 
 # Clone ansible-tdp-roles repository (doesn't fail iof not known host)
-[[ -d "$TDP_ROLES_PATH" ]] || git clone -o StrictHostKeyChecking=no git@github.com:TOSIT-IO/tdp-collection.git "$TDP_ROLES_PATH"
-[[ -d "$TDP_ROLES_EXTRA_PATH" ]] || git clone -o StrictHostKeyChecking=no git@github.com:TOSIT-IO/tdp-collection-extras.git "$TDP_ROLES_EXTRA_PATH"
+[[ -d "$TDP_ROLES_PATH" ]] || scripts/git-commit-download.sh $TDP_ROLES_PATH $TDP_COLLECTION_URL $TDP_COLLECTION_COMMIT
+
+[[ -d "$TDP_ROLES_EXTRA_PATH" ]] || scripts/git-commit-download.sh $TDP_ROLES_EXTRA_PATH $TDP_COLLECTION_EXTRAS_URL $TDP_COLLECTION_EXTRAS_COMMIT
 
 # Quick fix for file lookup related to the Hadoop role refactor (https://github.com/TOSIT-FR/ansible-tdp-roles/pull/57)
-[[ -d "$TDP_ROLES_PATH/playbooks/files" ]] || ln -s "$(realpath "$root_dir")/files" "$TDP_ROLES_PATH/playbooks"
+
+[[ -d $TDP_ROLES_PATH/playbooks/files ]] || ln -s $PWD/files $TDP_ROLES_PATH/playbooks
 
 # Copy the default tdp_vars
 [[ -d inventory/tdp_vars ]] || cp -r ansible_roles/collections/ansible_collections/tosit/tdp/tdp_vars_defaults inventory/tdp_vars
 
 # Read the TDP releases from file
-tdp_release_uris=$(grep -P '^[^#]' <"$root_dir/scripts/tdp-release-uris.txt")
+tdp_release_uris=$(sed -E '/^[[:blank:]]*(#|$)/d; s/#.*//' $PWD/tdp-release-uris)
 
 # Fetch the TDP .tar.gz releases
 for tdp_release_uri in $tdp_release_uris; do
-    release_name=$(basename "$tdp_release_uri" | grep -oP '^([^?]+)')
+    release_name=$(basename $tdp_release_uri)
     # Fetch the TDP .tar.gz releases
-    [[ -f "$root_dir/files/$release_name" ]] || wget "$tdp_release_uri" -nc -nd -O "$root_dir/files/$release_name"
+    [[ -f "$PWD/files/$release_name" ]] || wget $tdp_release_uri -nc -nd -O $PWD/files/$release_name
 done

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,8 +5,6 @@
 # virtual TDP cluster using the TDP-getting-started repo
 ###
 
-
-
 # tdp-collection
 TDP_COLLECTION_URL=https://github.com/TOSIT-IO/tdp-collection
 TDP_ROLES_PATH=ansible_roles/collections/ansible_collections/tosit/tdp
@@ -26,23 +24,22 @@ mkdir -p logs
 mkdir -p files
 
 # Clone ansible-tdp-roles repository (doesn't fail iof not known host)
-[[ -d "$EXPANDED_TDP_ROLES_PATH" ]] || "$(realpath "$root_dir")/scripts/git-commit-download.sh" $EXPANDED_TDP_ROLES_PATH $TDP_COLLECTION_URL $TDP_COLLECTION_COMMIT
-
-[[ -d "$TDP_ROLES_EXTRA_PATH" ]] || "$(realpath "$root_dir")/scripts/git-commit-download.sh" $EXPANDED_TDP_ROLES_EXTRA_PATH $TDP_COLLECTION_EXTRAS_URL $TDP_COLLECTION_EXTRAS_COMMIT
+[[ -d "$EXPANDED_TDP_ROLES_PATH" ]] || "$(realpath "$root_dir")/scripts/git-commit-download.sh" "$EXPANDED_TDP_ROLES_PATH" "$TDP_COLLECTION_URL" "$TDP_COLLECTION_COMMIT"
+[[ -d "$TDP_ROLES_EXTRA_PATH" ]] || "$(realpath "$root_dir")/scripts/git-commit-download.sh" "$EXPANDED_TDP_ROLES_EXTRA_PATH" "$TDP_COLLECTION_EXTRAS_URL" "$TDP_COLLECTION_EXTRAS_COMMIT"
 
 # Quick fix for file lookup related to the Hadoop role refactor (https://github.com/TOSIT-FR/ansible-tdp-roles/pull/57)
-
-[[ -d $EXPANDED_TDP_ROLES_PATH/playbooks/files ]] || ln -s "$(realpath "$root_dir")/files" $EXPANDED_TDP_ROLES_PATH/playbooks
+[[ -d $EXPANDED_TDP_ROLES_PATH/playbooks/files ]] || ln -s "$(realpath "$root_dir")/files" "$EXPANDED_TDP_ROLES_PATH/playbooks"
+[[ -d $EXPANDED_TDP_ROLES_EXTRA_PATH/playbooks/files ]] || ln -s "$(realpath "$root_dir")/files" "$EXPANDED_TDP_ROLES_EXTRA_PATH/playbooks"
 
 # Copy the default tdp_vars
-[[ -d "$(realpath "$root_dir")/inventory/tdp_vars" ]] || cp -r $EXPANDED_TDP_ROLES_PATH/tdp_vars_defaults "$(realpath "$root_dir")/inventory/tdp_vars"
+[[ -d "$(realpath "$root_dir")/inventory/tdp_vars" ]] || cp -r "$EXPANDED_TDP_ROLES_PATH/tdp_vars_defaults" "$(realpath "$root_dir")/inventory/tdp_vars"
 
 # Read the TDP releases from file
-tdp_release_uris=$(sed -E '/^[[:blank:]]*(#|$)/d; s/#.*//' "$(realpath "$root_dir")/scripts/tdp-release-uris.txt")
+tdp_release_uris=$(grep -P '^[^#]' <"$(realpath "$root_dir")/scripts/tdp-release-uris.txt")
 
 # Fetch the TDP .tar.gz releases
 for tdp_release_uri in $tdp_release_uris; do
-    release_name=$(basename $tdp_release_uri)
+    release_name=$(basename "$tdp_release_uri")
     # Fetch the TDP .tar.gz releases
-    [[ -f "$(realpath "$root_dir")/files/$release_name" ]] || wget $tdp_release_uri -nc -nd -O "$(realpath "$root_dir")/files/$release_name"
+    [[ -f "$(realpath "$root_dir")/files/$release_name" ]] || wget "$tdp_release_uri" -nc -nd -O "$(realpath "$root_dir")/files/$release_name"
 done

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,7 +14,7 @@ TDP_COLLECTION_COMMIT=86f2d3f42df18a5ac07cc25e847ddaf3082be6d4
 
 # tdp-collection-extras
 TDP_COLLECTION_EXTRAS_URL=https://github.com/TOSIT-IO/tdp-collection-extras
-TDP_ROLES_EXTRA_PATH=ansible_roles/collections/ansible_collections/tosit/tdp-extra
+TDP_ROLES_EXTRA_PATH=ansible_roles/collections/ansible_collections/tosit/tdp_extra
 TDP_COLLECTION_EXTRAS_COMMIT=1035ca7f3f67275140cd15478d043b543679ec30
 
 root_dir="$(dirname "$0")/.." # project root dir


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Fixes #68

#### Additional comments:
Conclusion of some discussions on the strategy to remove the nested clones was to not use git submodules (because it's complicated to use submodules and symbolic links together).

Settled for github archive download which has added bonus of enabling the download of a specific commit in the history, avoiding future pushes to tdp-collection and tdp-collection-extras breaking tdp-getting-started.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.


