### PR TITLE
fix(livy): remove redundant livy deployments

### DIFF
--- a/deploy-all.yml
+++ b/deploy-all.yml
@@ -12,7 +12,9 @@
 - import_playbook: deploy-hive.yml
 - import_playbook: deploy-hbase.yml
 - import_playbook: deploy-spark.yml
+- import_playbook: deploy-livy.yml
 - import_playbook: deploy-spark3.yml
+- import_playbook: deploy-livy-spark3.yml
 - import_playbook: deploy-knox.yml
 - import_playbook: deploy-kafka.yml
 - import_playbook: deploy-users.yml

--- a/deploy-all.yml
+++ b/deploy-all.yml
@@ -12,9 +12,7 @@
 - import_playbook: deploy-hive.yml
 - import_playbook: deploy-hbase.yml
 - import_playbook: deploy-spark.yml
-- import_playbook: deploy-livy.yml
 - import_playbook: deploy-spark3.yml
-- import_playbook: deploy-livy-spark3.yml
 - import_playbook: deploy-knox.yml
 - import_playbook: deploy-kafka.yml
 - import_playbook: deploy-users.yml

--- a/deploy-spark.yml
+++ b/deploy-spark.yml
@@ -10,6 +10,3 @@
 
 - name: Deploy Spark
   import_playbook: ansible_roles/collections/ansible_collections/tosit/tdp/playbooks/meta/spark.yml
-
-- name: Deploy Livy
-  import_playbook: ansible_roles/collections/ansible_collections/tosit/tdp_extra/playbooks/meta/livy.yml

--- a/deploy-spark3.yml
+++ b/deploy-spark3.yml
@@ -1,6 +1,3 @@
 ---
 - name: Deploy Spark3
   import_playbook: ansible_roles/collections/ansible_collections/tosit/tdp/playbooks/meta/spark3.yml
-
-- name: Deploy Livy for Spark 3
-  import_playbook: ansible_roles/collections/ansible_collections/tosit/tdp_extra/playbooks/meta/livy-spark3.yml


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #174 

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->
Simplification of `deploy-all.yml` since livy and livy for spark3 deployments are already included in `deploy-spark.yml` and `deploy-spark3.yml`.

---
To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.


