### PR TITLE
feat: use `auto` python interpreter

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,6 +6,7 @@ private_key_file = files/tdp-rsa
 log_path = logs/tdp.log
 hash_behaviour = merge
 stdout_callback = yaml
+interpreter_python = auto
 
 [privilege_escalation]
 become=True


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #277 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

What we had  'auto_legacy' :

Detects the target OS platform, distribution, and version, then consults a table listing the correct Python interpreter and path for each platform/distribution/version. If an entry is found, and /usr/bin/python is absent, uses the discovered interpreter (and path). If an entry is found, and /usr/bin/python is present, uses /usr/bin/python and issues a warning. This exception provides temporary compatibility with previous versions of Ansible that always defaulted to /usr/bin/python, so if you have installed Python and other dependencies at /usr/bin/python on some hosts, Ansible will find and use them with this setting. If no entry is found, or the listed Python is not present on the target host, searches a list of common Python interpreter paths and uses the first one found; also issues a warning that future installation of another Python interpreter could alter the one chosen.

What we have after this PR
auto(default in 2.12)

Detects the target OS platform, distribution, and version, then consults a table listing the correct Python interpreter and path for each platform/distribution/version. If an entry is found, uses the discovered interpreter. If no entry is found, or the listed Python is not present on the target host, searches a list of common Python interpreter paths and uses the first one found; also issues a warning that future installation of another Python interpreter could alter the one chosen.




#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
