### PR TITLE
fix: prevent script from exiting when file already exist

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -326,7 +326,7 @@ download_tdp_binaries() {
   do
     if [[ -n "$file_name" ]]
     then
-      wget --no-clobber --output-document=files/${file_name} ${uri_file_name}
+      wget --no-clobber --output-document=files/${file_name} ${uri_file_name} || true
     else
       wget --no-clobber --directory-prefix="files" ${uri_file_name}
     fi


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

`wget` used with both `--no-clober` and `--output-document` options exit with a non-zero status when the file already exist.
This cause the script to stop because of `set -e`. Hence, the script won't download the remaining files.

An alternative solution would be:

```sh
download_tdp_binaries() {
  while IFS=";" read -r uri_file_name file_name
  do
    local target_file=${file_name:-$(basename ${uri_file_name})}
    if [[ -f "files/${target_file}" ]]
    then
      echo "File 'files/${target_file}' already exists. Skipping download."
    else
      wget --output-document="files/${target_file}" ${uri_file_name}
    fi
  done < scripts/tdp-release-uris.txt
}
```

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
